### PR TITLE
fix: handle empty labels in groups

### DIFF
--- a/src/workflow/job.rs
+++ b/src/workflow/job.rs
@@ -46,7 +46,10 @@ pub enum RunsOn {
     Target(Vec<String>),
     Group {
         group: String,
-        #[serde(deserialize_with = "crate::common::scalar_or_vector")]
+        // NOTE(ww): serde struggles with the null/empty case for custom
+        // deserializers, so we help it out by telling it that it can default
+        // to Vec::default.
+        #[serde(deserialize_with = "crate::common::scalar_or_vector", default)]
         labels: Vec<String>,
     },
 }

--- a/tests/sample-workflows/runs-on-group-only.yml
+++ b/tests/sample-workflows/runs-on-group-only.yml
@@ -1,0 +1,14 @@
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#choosing-runners-in-a-group
+name: learn-github-actions
+on: [push]
+jobs:
+  check-bats-version:
+    runs-on:
+      group: ubuntu-runners
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "14"
+      - run: npm install -g bats
+      - run: bats -v


### PR DESCRIPTION
This handles `runs-on` definitions where a `group` is present but no `labels` are present, which is valid per https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#choosing-runners-in-a-group.
