### PR TITLE
fix: null env values are empty strings

### DIFF
--- a/src/workflow/job.rs
+++ b/src/workflow/job.rs
@@ -176,10 +176,7 @@ mod tests {
         let Secrets::Env(secrets) = serde_yaml::from_str::<Secrets>(secrets).unwrap() else {
             panic!("unexpected secrets variant");
         };
-        assert_eq!(
-            secrets["foo-secret"].as_ref().unwrap(),
-            &EnvValue::String("bar".into())
-        );
+        assert_eq!(secrets["foo-secret"], EnvValue::String("bar".into()));
     }
 
     #[test]

--- a/tests/test_workflow.rs
+++ b/tests/test_workflow.rs
@@ -55,15 +55,9 @@ fn test_pip_audit_ci() {
         panic!("expected uses step");
     };
     assert_eq!(uses, "actions/setup-python@v5");
-    assert_eq!(
-        with["python-version"].as_ref().unwrap().to_string(),
-        "${{ matrix.python }}"
-    );
-    assert_eq!(with["cache"].as_ref().unwrap().to_string(), "pip");
-    assert_eq!(
-        with["cache-dependency-path"].as_ref().unwrap().to_string(),
-        "pyproject.toml"
-    );
+    assert_eq!(with["python-version"].to_string(), "${{ matrix.python }}");
+    assert_eq!(with["cache"].to_string(), "pip");
+    assert_eq!(with["cache-dependency-path"].to_string(), "pyproject.toml");
 
     let StepBody::Run {
         run,


### PR DESCRIPTION
#10 fixed the problem but adds more typestates than actually necessary, since everything in an `Env` gets stringified eventually anyways.