### PR TITLE
fix: runs-on can be an expressions

### DIFF
--- a/src/workflow/job.rs
+++ b/src/workflow/job.rs
@@ -21,7 +21,7 @@ pub struct NormalJob {
     #[serde(default, deserialize_with = "crate::common::scalar_or_vector")]
     pub needs: Vec<String>,
     pub r#if: Option<If>,
-    pub runs_on: RunsOn,
+    pub runs_on: LoE<RunsOn>,
     pub environment: Option<DeploymentEnvironment>,
     pub concurrency: Option<Concurrency>,
     #[serde(default)]

--- a/tests/sample-workflows/runs-on-expr.yml
+++ b/tests/sample-workflows/runs-on-expr.yml
@@ -1,0 +1,12 @@
+name: runs-on-expr
+on: [push]
+jobs:
+  check-bats-version:
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "14"
+      - run: npm install -g bats
+      - run: bats -v

--- a/tests/test_workflow.rs
+++ b/tests/test_workflow.rs
@@ -1,9 +1,12 @@
 use std::{env, path::Path};
 
-use github_actions_models::workflow::{
-    event::OptionalBody,
-    job::{RunsOn, StepBody},
-    Job, Trigger, Workflow,
+use github_actions_models::{
+    common::expr::{ExplicitExpr, LoE},
+    workflow::{
+        event::OptionalBody,
+        job::{RunsOn, StepBody},
+        Job, Trigger, Workflow,
+    },
 };
 
 fn load_workflow(name: &str) -> Workflow {
@@ -41,7 +44,7 @@ fn test_pip_audit_ci() {
     assert_eq!(test_job.name, None);
     assert_eq!(
         test_job.runs_on,
-        RunsOn::Target(vec!["ubuntu-latest".to_string()])
+        LoE::Literal(RunsOn::Target(vec!["ubuntu-latest".to_string()]))
     );
     assert_eq!(test_job.steps.len(), 3);
 
@@ -72,4 +75,17 @@ fn test_pip_audit_ci() {
     assert!(working_directory.is_none());
     assert!(shell.is_none());
     assert!(env.is_empty());
+}
+
+#[test]
+fn test_runs_on_expr() {
+    let workflow = load_workflow("runs-on-expr.yml");
+
+    let job = workflow.jobs.get("check-bats-version").unwrap();
+    let Job::NormalJob(job) = job else { panic!() };
+
+    assert_eq!(
+        job.runs_on,
+        LoE::Expr(ExplicitExpr::from_curly("${{ matrix.runner }}").unwrap())
+    );
 }


### PR DESCRIPTION
This was silently "working" before because the expression was being treated as a label.

This is a stepping stone towards inferring the "default" shell for a runner.
