### PR TITLE
fix: use IndexMap and IndexSet everywhere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["github", "ci"]
 categories = ["api-bindings"]
 
 [dependencies]
+indexmap = { version = "2.7.0", features = ["serde"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_yaml = "0.9.29"
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -7,8 +7,7 @@
 //! [Metadata syntax for GitHub Actions]: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
 //! [JSON Schema definition for GitHub Actions]: https://json.schemastore.org/github-action.json
 
-use std::collections::HashMap;
-
+use indexmap::IndexMap;
 use serde::Deserialize;
 
 use crate::common::{expr::BoE, Env, If};
@@ -21,9 +20,9 @@ pub struct Action {
     pub author: Option<String>,
     pub description: Option<String>,
     #[serde(default)]
-    pub inputs: HashMap<String, Input>,
+    pub inputs: IndexMap<String, Input>,
     #[serde(default)]
-    pub outputs: HashMap<String, Output>,
+    pub outputs: IndexMap<String, Output>,
     pub runs: Runs,
 }
 
@@ -145,7 +144,7 @@ pub struct UseAction {
 
     /// Any inputs to the action being used.
     #[serde(default)]
-    pub with: HashMap<String, String>,
+    pub with: IndexMap<String, String>,
 
     /// An optional expression that prevents this step from running unless it evaluates to `true`.
     pub r#if: Option<If>,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,8 @@
 //! Shared models and utilities.
 
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize};
 
 pub mod expr;
@@ -16,7 +17,7 @@ pub enum Permissions {
     ///
     /// These are modeled with an open-ended mapping rather than a structure
     /// to make iteration over all defined permissions easier.
-    Explicit(HashMap<String, Permission>),
+    Explicit(IndexMap<String, Permission>),
 }
 
 impl Default for Permissions {
@@ -55,7 +56,7 @@ pub enum Permission {
 }
 
 /// An environment mapping.
-pub type Env = HashMap<String, EnvValue>;
+pub type Env = IndexMap<String, EnvValue>;
 
 /// Environment variable values are always strings, but GitHub Actions
 /// allows users to configure them as various native YAML types before
@@ -157,7 +158,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use indexmap::IndexMap;
 
     use crate::common::{BasePermission, Env, EnvValue, Permission};
 
@@ -173,7 +174,7 @@ mod tests {
         let perm = "security-events: write";
         assert_eq!(
             serde_yaml::from_str::<Permissions>(perm).unwrap(),
-            Permissions::Explicit(HashMap::from([(
+            Permissions::Explicit(IndexMap::from([(
                 "security-events".into(),
                 Permission::Write
             )]))

--- a/src/dependabot/v2.rs
+++ b/src/dependabot/v2.rs
@@ -4,8 +4,7 @@
 //! * [Configuration options for the `dependabot.yml` file](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
 //! * [JSON Schema for Dependabot v2](https://json.schemastore.org/dependabot-2.0.json)
 
-use std::collections::{HashMap, HashSet};
-
+use indexmap::{IndexMap, IndexSet};
 use serde::Deserialize;
 
 /// A `dependabot.yml` configuration file.
@@ -17,7 +16,7 @@ pub struct Dependabot {
     #[serde(default)]
     pub enable_beta_ecosystems: bool,
     #[serde(default)]
-    pub registries: HashMap<String, Registry>,
+    pub registries: IndexMap<String, Registry>,
     pub updates: Vec<Update>,
 }
 
@@ -96,11 +95,11 @@ pub struct Update {
     #[serde(default)]
     pub allow: Vec<Allow>,
     #[serde(default)]
-    pub assignees: HashSet<String>,
+    pub assignees: IndexSet<String>,
     pub commit_message: Option<CommitMessage>,
     pub directory: String,
     #[serde(default)]
-    pub groups: HashMap<String, Group>,
+    pub groups: IndexMap<String, Group>,
     #[serde(default)]
     pub ignore: Vec<Ignore>,
     #[serde(default)]
@@ -109,7 +108,7 @@ pub struct Update {
     ///
     /// The default label is `dependencies`.
     #[serde(default = "default_labels")]
-    pub labels: HashSet<String>,
+    pub labels: IndexSet<String>,
     pub milestone: Option<u64>,
     /// The maximum number of pull requests to open at a time from this
     /// update group.
@@ -124,7 +123,7 @@ pub struct Update {
     #[serde(default, deserialize_with = "crate::common::scalar_or_vector")]
     pub registries: Vec<String>,
     #[serde(default)]
-    pub reviewers: HashSet<String>,
+    pub reviewers: IndexSet<String>,
     pub schedule: Schedule,
     pub target_branch: Option<String>,
     #[serde(default)]
@@ -133,8 +132,8 @@ pub struct Update {
 }
 
 #[inline]
-fn default_labels() -> HashSet<String> {
-    HashSet::from(["dependencies".to_string()])
+fn default_labels() -> IndexSet<String> {
+    IndexSet::from(["dependencies".to_string()])
 }
 
 #[inline]
@@ -180,11 +179,11 @@ pub struct Group {
     /// [`DependencyType::Production`].
     pub dependency_type: Option<DependencyType>,
     #[serde(default)]
-    pub patterns: HashSet<String>,
+    pub patterns: IndexSet<String>,
     #[serde(default)]
-    pub exclude_patterns: HashSet<String>,
+    pub exclude_patterns: IndexSet<String>,
     #[serde(default)]
-    pub update_types: HashSet<UpdateType>,
+    pub update_types: IndexSet<UpdateType>,
 }
 
 /// Update types for grouping.
@@ -204,9 +203,9 @@ pub struct Ignore {
     /// These are, inexplicably, not [`UpdateType`] variants.
     /// Instead, they're strings like `"version-update:semver-{major,minor,patch}"`.
     #[serde(default)]
-    pub update_types: HashSet<String>,
+    pub update_types: IndexSet<String>,
     #[serde(default)]
-    pub versions: HashSet<String>,
+    pub versions: IndexSet<String>,
 }
 
 /// An "allow"/"deny" toggle.

--- a/src/workflow/event.rs
+++ b/src/workflow/event.rs
@@ -1,7 +1,6 @@
 //! Workflow events.
 
-use std::collections::HashMap;
-
+use indexmap::IndexMap;
 use serde::Deserialize;
 
 /// "Bare" workflow event triggers.
@@ -180,11 +179,11 @@ pub struct Cron {
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowCall {
     #[serde(default)]
-    pub inputs: HashMap<String, WorkflowCallInput>,
+    pub inputs: IndexMap<String, WorkflowCallInput>,
     #[serde(default)]
-    pub outputs: HashMap<String, WorkflowCallOutput>,
+    pub outputs: IndexMap<String, WorkflowCallOutput>,
     #[serde(default)]
-    pub secrets: HashMap<String, WorkflowCallSecret>,
+    pub secrets: IndexMap<String, WorkflowCallSecret>,
 }
 
 /// A single input in a `workflow_call` event trigger body.
@@ -219,7 +218,7 @@ pub struct WorkflowCallSecret {
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowDispatch {
     #[serde(default)]
-    pub inputs: HashMap<String, WorkflowDispatchInput>, // TODO: WorkflowDispatchInput
+    pub inputs: IndexMap<String, WorkflowDispatchInput>, // TODO: WorkflowDispatchInput
 }
 
 /// A single input in a `workflow_dispatch` event trigger body.

--- a/src/workflow/job.rs
+++ b/src/workflow/job.rs
@@ -1,7 +1,6 @@
 //! Workflow jobs.
 
-use std::collections::HashMap;
-
+use indexmap::IndexMap;
 use serde::{de, Deserialize, Serialize};
 use serde_yaml::Value;
 
@@ -25,7 +24,7 @@ pub struct NormalJob {
     pub environment: Option<DeploymentEnvironment>,
     pub concurrency: Option<Concurrency>,
     #[serde(default)]
-    pub outputs: HashMap<String, String>,
+    pub outputs: IndexMap<String, String>,
     #[serde(default)]
     pub env: Env,
     pub defaults: Option<Defaults>,
@@ -36,7 +35,7 @@ pub struct NormalJob {
     pub continue_on_error: BoE,
     pub container: Option<Container>,
     #[serde(default)]
-    pub services: HashMap<String, Container>,
+    pub services: IndexMap<String, Container>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -126,11 +125,11 @@ pub struct Strategy {
 #[serde(rename_all = "kebab-case")]
 pub struct Matrix {
     #[serde(default)]
-    pub include: LoE<Vec<HashMap<String, Value>>>,
+    pub include: LoE<Vec<IndexMap<String, Value>>>,
     #[serde(default)]
-    pub exclude: LoE<Vec<HashMap<String, Value>>>,
+    pub exclude: LoE<Vec<IndexMap<String, Value>>>,
     #[serde(flatten)]
-    pub dimensions: LoE<HashMap<String, LoE<Vec<Value>>>>,
+    pub dimensions: LoE<IndexMap<String, LoE<Vec<Value>>>>,
 }
 
 #[derive(Deserialize)]

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -7,8 +7,7 @@
 //! [Workflow Syntax for GitHub Actions]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions>
 //! [JSON Schema definition for workflows]: https://json.schemastore.org/github-workflow.json
 
-use std::collections::HashMap;
-
+use indexmap::IndexMap;
 use serde::Deserialize;
 
 use crate::common::{expr::BoE, Env, Permissions};
@@ -29,7 +28,7 @@ pub struct Workflow {
     pub env: Env,
     pub defaults: Option<Defaults>,
     pub concurrency: Option<Concurrency>,
-    pub jobs: HashMap<String, Job>,
+    pub jobs: IndexMap<String, Job>,
 }
 
 /// The triggering condition or conditions for a workflow.

--- a/tests/test_dependabot_v2.rs
+++ b/tests/test_dependabot_v2.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashSet, path::Path};
+use std::path::Path;
 
 use github_actions_models::dependabot::v2::{
     Dependabot, Interval, PackageEcosystem, RebaseStrategy,
 };
+use indexmap::IndexSet;
 
 fn load_dependabot(name: &str) -> Dependabot {
     let workflow_path = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -47,7 +48,7 @@ fn test_contents() {
     assert_eq!(github_actions.groups.len(), 1);
     assert_eq!(
         github_actions.groups["actions"].patterns,
-        HashSet::from(["*".to_string()])
+        IndexSet::from(["*".to_string()])
     );
 
     let github_actions = &dependabot.updates[2];
@@ -61,6 +62,6 @@ fn test_contents() {
     assert_eq!(github_actions.groups.len(), 1);
     assert_eq!(
         github_actions.groups["actions"].patterns,
-        HashSet::from(["*".to_string()])
+        IndexSet::from(["*".to_string()])
     );
 }


### PR DESCRIPTION
We always want to iterate jobs, etc. in their
exact order of insertion.