### PR TITLE
better documentation of the copyright/license situation of the test files

### DIFF
--- a/tests/sample-actions/gh-action-pypi-publish.yml
+++ b/tests/sample-actions/gh-action-pypi-publish.yml
@@ -1,4 +1,34 @@
 # https://github.com/pypa/gh-action-pypi-publish/blob/2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf/action.yml
+
+# Copyright 2019 Sviatoslav Sydorenko
+#
+# Licensed under the BSD-3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of gh-action-pypi-publish nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
 ---
 name: pypi-publish
 description: Upload Python distribution packages to PyPI

--- a/tests/sample-actions/setup-python.yml
+++ b/tests/sample-actions/setup-python.yml
@@ -1,4 +1,27 @@
 # https://github.com/actions/setup-python/blob/e9d6f990972a57673cdb72ec29e19d42ba28880f/action.yml
+
+# Copyright 2018 GitHub, Inc. and contributors
+#
+# Licensed under the MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 ---
 name: "Setup Python"
 description: "Set up a specific version of Python and add the command-line tools to the PATH."

--- a/tests/sample-dependabot/v2/sigstore-python.yml
+++ b/tests/sample-dependabot/v2/sigstore-python.yml
@@ -1,4 +1,19 @@
 # https://github.com/sigstore/sigstore-python/blob/e0168a781b87d059fde05dfdfe0ce82e564ce095/.github/dependabot.yml
+
+# Copyright 2022 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: 2
 
 updates:

--- a/tests/sample-workflows/adafruit-circuitpython-run-tests.yml
+++ b/tests/sample-workflows/adafruit-circuitpython-run-tests.yml
@@ -1,4 +1,27 @@
 # https://github.com/adafruit/circuitpython/blob/24a8927d0ce1d77addd584bf809ab73cb0386e75/.github/workflows/run-tests.yml
+
+# Copyright 2013-2023 Damien P. George
+#
+# Licensed under the MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 name: Run tests
 
 on:

--- a/tests/sample-workflows/gh-action-sigstore-python-selftest.yml
+++ b/tests/sample-workflows/gh-action-sigstore-python-selftest.yml
@@ -1,4 +1,19 @@
 # https://github.com/sigstore/gh-action-sigstore-python/blob/b3690e3a279c94669b1e9e4e1e29317cdc7a52d5/.github/workflows/selftest.yml
+
+# Copyright 2022 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Self-test
 
 on:

--- a/tests/sample-workflows/git-annex-built-windows.yaml
+++ b/tests/sample-workflows/git-annex-built-windows.yaml
@@ -1,4 +1,12 @@
 # https://github.com/datalad/git-annex/blob/58898b7a9185a94852ac059c3ff1cc3f2fd6deef/.github/workflows/build-windows.yaml
+
+# Copyright 2022 The Sigstore Authors
+#
+# Licensed under the GNU AFFERO GENERAL PUBLIC LICENSE Version 3
+#
+#      https://git-annex.branchable.com/license/AGPL
+#
+
 name: Build git-annex on Windows
 
 on:

--- a/tests/sample-workflows/homebrew-core-automerge-triggers.yml
+++ b/tests/sample-workflows/homebrew-core-automerge-triggers.yml
@@ -1,4 +1,29 @@
 # https://github.com/Homebrew/homebrew-core/blob/ac74cb3f7dbdb2da2200886d5e740de124bab861/.github/workflows/automerge-triggers.yml
+#
+# Copyright 2009-2024, Homebrew contributors
+#
+# Licensed under the BSD 2-Clause License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#   * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 name: Trigger automerge
 
 on:

--- a/tests/sample-workflows/homebrew-core-dispatch-rebottle.yml
+++ b/tests/sample-workflows/homebrew-core-dispatch-rebottle.yml
@@ -1,4 +1,29 @@
 # https://github.com/Homebrew/homebrew-core/blob/8b4101be35fb7053e2026edcf1f7d218a5ac3379/.github/workflows/dispatch-rebottle.yml#L4
+#
+# Copyright 2009-2024, Homebrew contributors
+#
+# Licensed under the BSD 2-Clause License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#   * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+#   * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 name: Dispatch rebottle (for all currently bottled OS versions)
 
 run-name: Rebuild bottles of ${{ inputs.formula }}

--- a/tests/sample-workflows/jazzband-tablib-docs-lint.yml
+++ b/tests/sample-workflows/jazzband-tablib-docs-lint.yml
@@ -1,4 +1,29 @@
 # https://raw.githubusercontent.com/jazzband/tablib/dcab406c553fc8b3c2e0aef955e9e8adea0590d8/.github/workflows/docs-lint.yml
+
+# Copyright:
+#  2016 Kenneth Reitz
+#  2019 Jazzband
+#
+# Licensed under the MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 name: Docs and lint
 
 on: [push, pull_request, workflow_dispatch]

--- a/tests/sample-workflows/letsencrypt-boulder-boulder-ci.yml
+++ b/tests/sample-workflows/letsencrypt-boulder-boulder-ci.yml
@@ -1,6 +1,13 @@
 # https://github.com/letsencrypt/boulder/blob/e182d889b220421caefbf384b36467f771b5f8d3/.github/workflows/boulder-ci.yml
 # Boulder CI test suite workflow
 
+# Copyright: 2014-2024 The Boulder Developers
+#
+# Licensed under the Mozilla Public License 2.0
+#
+# https://github.com/letsencrypt/boulder/blob/main/LICENSE.txt
+#
+
 name: Boulder CI
 
 # Controls when the action will run.

--- a/tests/sample-workflows/pip-api-test.yml
+++ b/tests/sample-workflows/pip-api-test.yml
@@ -1,4 +1,19 @@
 # https://github.com/di/pip-api/blob/60691ed6bdc0c213253593de869bff1cf9195b81/.github/workflows/test.yml
+
+# Copyright: 2018-2024 Dustin Ingram
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Test
 on: [push, pull_request]
 concurrency:

--- a/tests/sample-workflows/pip-audit-ci.yml
+++ b/tests/sample-workflows/pip-audit-ci.yml
@@ -1,4 +1,19 @@
 # https://github.com/pypa/pip-audit/blob/1fd67af0653a8e66b9470adab2e408a435632f19/.github/workflows/ci.yml
+
+# Copyright: 2021-2024 Alex Cameron
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: CI
 
 on:

--- a/tests/sample-workflows/pip-audit-scorecards.yml
+++ b/tests/sample-workflows/pip-audit-scorecards.yml
@@ -1,4 +1,19 @@
 # https://github.com/pypa/pip-audit/blob/1fd67af0653a8e66b9470adab2e408a435632f19/.github/workflows/scorecards.yml
+
+# Copyright: 2021-2024 Alex Cameron
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Scorecards supply-chain security
 on:
   # Only the default branch is supported.

--- a/tests/sample-workflows/pwn-requests.yml
+++ b/tests/sample-workflows/pwn-requests.yml
@@ -1,5 +1,8 @@
 # from: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 
+# Copyright: 2021 Jaroslav Lobačevski
+# License: Unknown, maybe fair use? Code comes from blog post.
+
 # INSECURE. Provided as an example only.
 on: pull_request_target
 

--- a/tests/sample-workflows/pyca-cryptography-ci.yml
+++ b/tests/sample-workflows/pyca-cryptography-ci.yml
@@ -1,4 +1,8 @@
 # https://github.com/pyca/cryptography/blob/4a42c1c961c678d784de763d82794527c2374f2f/.github/workflows/ci.yml
+
+# Copyright 2013-2024, Individual Contributors to pyca/cryptography
+# License: Apache-2.0 license OR BSD-3-Clause license
+
 name: CI
 on:
   pull_request: {}

--- a/tests/sample-workflows/pypi-attestations-release.yml
+++ b/tests/sample-workflows/pypi-attestations-release.yml
@@ -1,4 +1,8 @@
 # https://github.com/trailofbits/pypi-attestations/blob/b5920dee025c93b2bfefbcccc6acc7eab7b8a18e/.github/workflows/release.yml
+
+# Copyright 2024 Trail of Bits
+# License: Apache-2.0
+
 on:
   release:
     types:

--- a/tests/sample-workflows/rnpgp-rnp-centos-and-fedora.yml
+++ b/tests/sample-workflows/rnpgp-rnp-centos-and-fedora.yml
@@ -1,4 +1,10 @@
 # https://github.com/rnpgp/rnp/blob/ddcbaa932f01a349969e9689de5bccd485090d02/.github/workflows/centos-and-fedora.yml
+
+# Copyright:
+#  2017-2024, Ribose Inc.
+#  2009-2010, The NetBSD Foundation, Inc.
+# License: BSD-2-clause
+
 name: centos-and-fedora
 on:
   push:

--- a/tests/sample-workflows/runs-on-group-only.yml
+++ b/tests/sample-workflows/runs-on-group-only.yml
@@ -1,4 +1,8 @@
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#choosing-runners-in-a-group
+
+# Copyright: 2024 GitHub, Inc.
+# License: Creative Commons Attribution 4.0 International
+
 name: learn-github-actions
 on: [push]
 jobs:


### PR DESCRIPTION
Hi, I started to work on a Debian package of this project, and needed to track down the copyright/licenses of the test files.

I thought that this can maybe be useful for someone else also.

One question regarding the file `tests/sample-workflows/pwn-requests.yml`, this seems to come from a blog post and don't have any license information as far as I can tell, would you argue that it is some form of fair use?