### PR TITLE
fix: allow reusable workflow calls to be unpinned

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -358,12 +358,10 @@ where
     let uses = step_uses(de)?;
 
     match uses {
-        Uses::Local(local) if local.git_ref.is_none() => Err(de::Error::custom(
-            "local action must have `@<ref>` in reusable workflow",
-        )),
         Uses::Repository(repo) if repo.git_ref.is_none() => Err(de::Error::custom(
             "repo action must have `@<ref> in reusable workflow",
         )),
+        // NOTE: local reusable workflows do not have to be pinned.
         Uses::Local(_) => Ok(uses),
         Uses::Repository(_) => Ok(uses),
         // `docker://` is never valid in reusable workflow uses.

--- a/tests/sample-workflows/reusable-workflow-unpinned.yml
+++ b/tests/sample-workflows/reusable-workflow-unpinned.yml
@@ -1,0 +1,11 @@
+# see https://github.com/woodruffw/zizmor/issues/431
+
+name: "reusable-workflow-unpinned"
+
+on:
+  push:
+
+jobs:
+  testcase:
+    name: "testcase"
+    uses: ./.github/workflows/reusable.yml

--- a/tests/test_workflow.rs
+++ b/tests/test_workflow.rs
@@ -24,10 +24,12 @@ fn load_workflow(name: &str) -> Workflow {
 fn test_load_all() {
     let sample_workflows = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/sample-workflows");
 
-    for sample_action in std::fs::read_dir(sample_workflows).unwrap() {
-        let sample_workflow = sample_action.unwrap().path();
-        let workflow_contents = std::fs::read_to_string(sample_workflow).unwrap();
-        serde_yaml::from_str::<Workflow>(&workflow_contents).unwrap();
+    for sample_workflow in std::fs::read_dir(sample_workflows).unwrap() {
+        let sample_workflow = sample_workflow.unwrap().path();
+        let workflow_contents = std::fs::read_to_string(&sample_workflow).unwrap();
+
+        let wf = serde_yaml::from_str::<Workflow>(&workflow_contents);
+        assert!(wf.is_ok(), "failed to parse {sample_workflow:?}");
     }
 }
 


### PR DESCRIPTION
See https://github.com/woodruffw/zizmor/issues/431