### PR TITLE
Implement `Debug` for all public types

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -16,7 +16,7 @@ use crate::common::{
 };
 
 /// A GitHub Actions action definition.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Action {
     /// The action's name.
@@ -33,7 +33,7 @@ pub struct Action {
 }
 
 /// An action input.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Input {
     // NOTE: documented as required, but experimentally it is not.
@@ -43,7 +43,7 @@ pub struct Input {
 }
 
 /// An action output.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Output {
     // NOTE: documented as required, but experimentally it is not.
@@ -56,7 +56,7 @@ pub struct Output {
 ///
 /// A `runs` definition can be either a JavaScript action, a "composite" action
 /// (made up of several constituent actions), or a Docker action.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum Runs {
     JavaScript(JavaScript),
@@ -65,7 +65,7 @@ pub enum Runs {
 }
 
 /// A `runs` definition for a JavaScript action.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct JavaScript {
     /// The Node runtime to use for this action. This is one of:
@@ -94,7 +94,7 @@ pub struct JavaScript {
 }
 
 /// A `runs` definition for a composite action.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Composite {
     /// Invariant: `"composite"`
@@ -106,7 +106,7 @@ pub struct Composite {
 /// An individual composite action step.
 ///
 /// This is similar, but not identical to [`crate::workflow::job::Step`].
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Step {
     /// An optional ID for this composite step.
@@ -129,7 +129,7 @@ pub struct Step {
 }
 
 /// The body of a composite action step.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum StepBody {
     /// A step that uses another GitHub Action.
@@ -160,7 +160,7 @@ pub enum StepBody {
 }
 
 /// A `runs` definition for a Docker action.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Docker {
     /// Invariant: `"docker"`

--- a/src/common.rs
+++ b/src/common.rs
@@ -31,7 +31,7 @@ impl Default for Permissions {
 
 /// "Base" permissions, where all individual permissions are configured
 /// with a blanket setting.
-#[derive(Deserialize, Default, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Default, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum BasePermission {
     /// Whatever default permissions come from the workflow's `GITHUB_TOKEN`.
@@ -44,7 +44,7 @@ pub enum BasePermission {
 }
 
 /// A singular permission setting.
-#[derive(Deserialize, Default, Debug, PartialEq)]
+#[derive(Deserialize, Debug, Default, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Permission {
     /// Read access.
@@ -68,7 +68,7 @@ pub type Env = IndexMap<String, EnvValue>;
 /// This type also gets used for other places where GitHub Actions
 /// contextually reinterprets a YAML value as a string, e.g. trigger
 /// input values.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum EnvValue {
     // Missing values are empty strings.
@@ -92,7 +92,7 @@ impl Display for EnvValue {
 /// key can have either a scalar value or an array of values.
 ///
 /// This only appears internally, as an intermediate type for `scalar_or_vector`.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq)]
 #[serde(untagged)]
 enum SoV<T> {
     One(T),
@@ -119,7 +119,7 @@ where
 /// A bool or string. This is useful for cases where GitHub Actions contextually
 /// reinterprets a YAML boolean as a string, e.g. `run: true` really means
 /// `run: 'true'`.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq)]
 #[serde(untagged)]
 enum BoS {
     Bool(bool),
@@ -138,7 +138,7 @@ impl From<BoS> for String {
 /// An `if:` condition in a job or action definition.
 ///
 /// These are either booleans or bare (i.e. non-curly) expressions.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum If {
     Bool(bool),

--- a/src/common/expr.rs
+++ b/src/common/expr.rs
@@ -69,7 +69,7 @@ impl<'de> Deserialize<'de> for ExplicitExpr {
 /// A "literal or expr" type, for places in GitHub Actions where a
 /// key can either have a literal value (array, object, etc.) or an
 /// expression string.
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum LoE<T> {
     // Observe that `Expr` comes first, since `LoE<String>` should always

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! High-quality data models for GitHub Actions and associated machinery.
 
+#![deny(missing_debug_implementations)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![allow(clippy::redundant_field_names)]
 #![forbid(unsafe_code)]

--- a/src/workflow/event.rs
+++ b/src/workflow/event.rs
@@ -13,7 +13,7 @@ use crate::common::EnvValue;
 /// ```yaml
 /// on: push
 /// ```
-#[derive(Deserialize, PartialEq, Eq, Hash)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum BareEvent {
     BranchProtectionRule,
@@ -57,7 +57,7 @@ pub enum BareEvent {
 /// Workflow event triggers, with bodies.
 ///
 /// Like [`BareEvent`], but with per-event properties.
-#[derive(Default, Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize, Debug)]
 #[serde(default, rename_all = "snake_case")]
 pub struct Events {
     pub branch_protection_rule: OptionalBody<GenericEvent>,
@@ -157,7 +157,7 @@ impl Events {
 /// between the non-presence of an event (no trigger) and the presence
 /// of an empty event body (e.g. `pull_request:`), which means "trigger
 /// with the defaults for this event type."
-#[derive(Default, Serialize)]
+#[derive(Default, Serialize, Debug)]
 pub enum OptionalBody<T> {
     Default,
     #[default]
@@ -187,7 +187,7 @@ impl<T> From<Option<T>> for OptionalBody<T> {
 }
 
 /// A generic event trigger body.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct GenericEvent {
     #[serde(default, deserialize_with = "crate::common::scalar_or_vector")]
@@ -195,7 +195,7 @@ pub struct GenericEvent {
 }
 
 /// The body of a `pull_request` event trigger.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct PullRequest {
     #[serde(default)]
@@ -209,7 +209,7 @@ pub struct PullRequest {
 }
 
 /// The body of a `push` event trigger.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Push {
     #[serde(flatten)]
@@ -223,14 +223,14 @@ pub struct Push {
 }
 
 /// The body of a `cron` event trigger.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Cron {
     pub cron: String,
 }
 
 /// The body of a `workflow_call` event trigger.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowCall {
     #[serde(default)]
@@ -242,7 +242,7 @@ pub struct WorkflowCall {
 }
 
 /// A single input in a `workflow_call` event trigger body.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowCallInput {
     pub description: Option<String>,
@@ -253,7 +253,7 @@ pub struct WorkflowCallInput {
 }
 
 /// A single output in a `workflow_call` event trigger body.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowCallOutput {
     pub description: Option<String>,
@@ -261,7 +261,7 @@ pub struct WorkflowCallOutput {
 }
 
 /// A single secret in a `workflow_call` event trigger body.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowCallSecret {
     pub description: Option<String>,
@@ -269,7 +269,7 @@ pub struct WorkflowCallSecret {
 }
 
 /// The body of a `workflow_dispatch` event trigger.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowDispatch {
     #[serde(default)]
@@ -277,7 +277,7 @@ pub struct WorkflowDispatch {
 }
 
 /// A single input in a `workflow_dispatch` event trigger body.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowDispatchInput {
     pub description: Option<String>,
@@ -292,7 +292,7 @@ pub struct WorkflowDispatchInput {
 }
 
 /// The body of a `workflow_run` event trigger.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowRun {
     pub workflows: Vec<String>,
@@ -303,7 +303,7 @@ pub struct WorkflowRun {
 }
 
 /// Branch filtering variants for event trigger bodies.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub enum BranchFilters {
     Branches(Vec<String>),
@@ -311,7 +311,7 @@ pub enum BranchFilters {
 }
 
 /// Tag filtering variants for event trigger bodies.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub enum TagFilters {
     Tags(Vec<String>),
@@ -319,7 +319,7 @@ pub enum TagFilters {
 }
 
 /// Path filtering variants for event trigger bodies.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub enum PathFilters {
     Paths(Vec<String>),

--- a/src/workflow/event.rs
+++ b/src/workflow/event.rs
@@ -57,7 +57,7 @@ pub enum BareEvent {
 /// Workflow event triggers, with bodies.
 ///
 /// Like [`BareEvent`], but with per-event properties.
-#[derive(Default, Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(default, rename_all = "snake_case")]
 pub struct Events {
     pub branch_protection_rule: OptionalBody<GenericEvent>,
@@ -157,7 +157,7 @@ impl Events {
 /// between the non-presence of an event (no trigger) and the presence
 /// of an empty event body (e.g. `pull_request:`), which means "trigger
 /// with the defaults for this event type."
-#[derive(Default, Serialize, Debug)]
+#[derive(Serialize, Debug, Default)]
 pub enum OptionalBody<T> {
     Default,
     #[default]

--- a/src/workflow/job.rs
+++ b/src/workflow/job.rs
@@ -38,7 +38,7 @@ pub struct NormalJob {
     pub services: IndexMap<String, Container>,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "kebab-case", untagged, remote = "Self")]
 pub enum RunsOn {
     #[serde(deserialize_with = "crate::common::scalar_or_vector")]

--- a/src/workflow/job.rs
+++ b/src/workflow/job.rs
@@ -11,7 +11,7 @@ use super::{Concurrency, Defaults};
 
 /// A "normal" GitHub Actions workflow job, i.e. a job composed of one
 /// or more steps on a runner.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct NormalJob {
     pub name: Option<String>,
@@ -75,14 +75,14 @@ impl<'de> Deserialize<'de> for RunsOn {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum DeploymentEnvironment {
     Name(String),
     NameURL { name: String, url: Option<String> },
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Step {
     /// An optional ID for this step.
@@ -107,7 +107,7 @@ pub struct Step {
     pub body: StepBody,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum StepBody {
     Uses {
@@ -137,7 +137,7 @@ pub enum StepBody {
     },
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Strategy {
     pub matrix: Option<LoE<Matrix>>,
@@ -145,7 +145,7 @@ pub struct Strategy {
     pub max_parallel: Option<LoE<u64>>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Matrix {
     #[serde(default)]
@@ -156,7 +156,7 @@ pub struct Matrix {
     pub dimensions: LoE<IndexMap<String, LoE<Vec<Value>>>>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum Container {
     Name(String),
@@ -172,13 +172,13 @@ pub enum Container {
     },
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct DockerCredentials {
     pub username: Option<String>,
     pub password: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct ReusableWorkflowCallJob {
     pub name: Option<String>,

--- a/src/workflow/mod.rs
+++ b/src/workflow/mod.rs
@@ -19,7 +19,7 @@ pub mod event;
 pub mod job;
 
 /// A single GitHub Actions workflow.
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Workflow {
     pub name: Option<String>,
@@ -57,7 +57,7 @@ pub struct Workflow {
 ///         branches: [main]
 ///       pull_request:
 ///     ```
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum Trigger {
     BareEvent(event::BareEvent),
@@ -65,20 +65,20 @@ pub enum Trigger {
     Events(Box<event::Events>),
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct Defaults {
     pub run: Option<RunDefaults>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct RunDefaults {
     pub shell: Option<String>,
     pub working_directory: Option<String>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum Concurrency {
     Bare(String),
@@ -89,7 +89,7 @@ pub enum Concurrency {
     },
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", untagged)]
 pub enum Job {
     NormalJob(Box<job::NormalJob>),


### PR DESCRIPTION
I put it immediately after `Serialize`/`Deserialize`, since after was more common. I also standardized the existing derives to `Deserialize, Serialize, Debug, …` order, but I can drop that commit if you'd prefer.

`Debug` implementations were checked with `cargo clippy -- -Wmissing_debug_implementations`