### PR TITLE
bugfix: make workflow_call.secrets.*.required optional

### DIFF
--- a/src/workflow/event.rs
+++ b/src/workflow/event.rs
@@ -263,6 +263,7 @@ pub struct WorkflowCallOutput {
 #[serde(rename_all = "kebab-case")]
 pub struct WorkflowCallSecret {
     pub description: Option<String>,
+    #[serde(default)]
     pub required: bool,
 }
 

--- a/tests/sample-workflows/zizmor-issue-646.yml
+++ b/tests/sample-workflows/zizmor-issue-646.yml
@@ -1,0 +1,15 @@
+# https://github.com/woodruffw/zizmor/issues/646
+
+name: Test
+
+on:
+  workflow_call:
+    secrets:
+      my-secret:
+        description: My secret
+
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ secrets.my-secret }}


### PR DESCRIPTION
This field is documented as required in the SchemaStore JSON, but is empirically not actually required by GitHub Actions.

See https://github.com/woodruffw/zizmor/issues/646.